### PR TITLE
Add migration for Git commit link of a work item

### DIFF
--- a/TfsMigrate.Core/WorkItemTracking/WorkItemRelationExtensions.cs
+++ b/TfsMigrate.Core/WorkItemTracking/WorkItemRelationExtensions.cs
@@ -78,5 +78,12 @@ namespace TfsMigrate.WorkItemTracking
         /// <param name="source">The source.</param>
         /// <returns><see langword="true"/> if the relationship matches or <see langword="false"/> otherwise.</returns>
         public static bool IsAttachment( this WorkItemRelation source ) => String.Compare(source.Rel ?? "", WorkItemRelations.Attachment, true) == 0;
+
+        /// <summary>Determines if this is a GitCommit relation.</summary>
+        /// <param name="source">The source.</param>
+        /// <returns><see langword="true"/> if the relationship matches or <see langword="false"/> otherwise.</returns>
+        public static bool IsGitCommit( this WorkItemRelation source ) =>
+            (String.Compare(source.Rel ?? "", WorkItemRelations.ArtefactLink, true) == 0) &&
+            (String.Compare(source.Attributes.ContainsKey("name") ? source.Attributes["name"].ToString() : "", WorkItemRelations.ArtefactLinkName_GitCommit, true) == 0);
     }
 }

--- a/TfsMigrate.Core/WorkItemTracking/WorkItemRelations.cs
+++ b/TfsMigrate.Core/WorkItemTracking/WorkItemRelations.cs
@@ -15,5 +15,9 @@ namespace TfsMigrate.WorkItemTracking
         public const string Related = "System.LinkTypes.Related";
 
         public const string Attachment = "AttachedFile";
+
+        public const string ArtefactLink = "ArtifactLink";
+
+        public const string ArtefactLinkName_GitCommit = "Fixed in Commit";
     }
 }

--- a/TfsMigrate.Processors.WorkItemTracking/WorkItemTrackingSettings.cs
+++ b/TfsMigrate.Processors.WorkItemTracking/WorkItemTrackingSettings.cs
@@ -23,10 +23,13 @@ namespace TfsMigrate.Processors.WorkItemTracking
 
         public TranslateSettings Translate { get; set; } = new TranslateSettings();
 
+        public List<RepositorySettings> Repositories { get; set; } = new List<RepositorySettings>();
+
         public bool IncludeRelatedLinksOnClosed { get; set; }
         public bool IncludeChildLinksOnClosed { get; set; }
         public bool IncludeParentLinksOnClosed { get; set; }
         public bool IncludeAttachmentFiles { get; set; }
+        public bool IncludeGitCommit { get; set; }
 
         public string MigrationTag { get; set; }
     }
@@ -112,5 +115,12 @@ namespace TfsMigrate.Processors.WorkItemTracking
         public List<StateSettings> States { get; set; }
 
         public List<SeveritySettings> Severity { get; set; }
+    }
+
+    public class RepositorySettings
+    {
+        public string Source { get; set; }
+
+        public string Target { get; set; }
     }
 }

--- a/TfsMigrate/settings.json
+++ b/TfsMigrate/settings.json
@@ -431,6 +431,16 @@
     // When set to true, the attachment files of work items will be included in migration
     "includeAttachmentFiles": true,
 
+    // When set to true, the Git commit linked to work items will be included in migration
+    "includeGitCommit": true,
+    // If Git commit is included to migration, defines the mappings between source repository id and target repository id.
+    "repositories": [
+      {
+        "source": "0082b728-cf7b-4268-ab26-c02a59a280ad",
+        "target": "1d0f3a14-cb5f-4af6-a713-72de0dcfc055"
+      }
+    ],
+
     // The tag to apply to migrated items
     "migrationTag": "tfs-migration",
 


### PR DESCRIPTION
Add Git commit link to relations can be migrated. 
- Setting `includeGitCommit` to keep git commit migration optional
- Setting `repositories` to define match between source and target repository